### PR TITLE
adding type check for empty arrays for object

### DIFF
--- a/index.js
+++ b/index.js
@@ -544,8 +544,8 @@ class ObjectType extends Type {
 			throw new MyTypeError('Expected an object for properties (found: %type)', propTypes);
 		}
 
-		if (Array.isArray(propTypes) && propTypes.length == 0) {
-				throw new MyTypeError('Expected an object for properties (found: empty array)');
+		if (Array.isArray(propTypes)) {
+			throw new MyTypeError('Expected an object for properties (found: array)');
 		}
 
 		this.propTypes = propTypes;
@@ -634,6 +634,10 @@ class ObjectType extends Type {
 
 		if (this.isOptional && (value === undefined || value === null)) {
 			return;
+		}
+
+		if(Array.isArray(value)) {
+			throw new MyTypeError(`Object is an array`, value);
 		}
 
 		// test provided properties

--- a/index.js
+++ b/index.js
@@ -544,6 +544,10 @@ class ObjectType extends Type {
 			throw new MyTypeError('Expected an object for properties (found: %type)', propTypes);
 		}
 
+		if (Array.isArray(propTypes) && propTypes.length == 0) {
+				throw new MyTypeError('Expected an object for properties (found: empty array)');
+		}
+
 		this.propTypes = propTypes;
 		this.propNames = Object.keys(propTypes);
 		this.dict = null;

--- a/index.js
+++ b/index.js
@@ -538,7 +538,7 @@ class ArrayType extends Type {
 class ObjectType extends Type {
 	constructor(propTypes, code) {
 		super();
-		this.addTest("value === null || typeof value !== 'object'", '%name is not an object (found: %type)', code);
+		this.addTest("value === null || typeof value !== 'object' || Array.isArray(value)", '%name is not an object (found: %type)', code);
 
 		if (!propTypes || typeof propTypes !== 'object') {
 			throw new MyTypeError('Expected an object for properties (found: %type)', propTypes);
@@ -634,10 +634,6 @@ class ObjectType extends Type {
 
 		if (this.isOptional && (value === undefined || value === null)) {
 			return;
-		}
-
-		if(Array.isArray(value)) {
-			throw new MyTypeError(`Object is an array`, value);
 		}
 
 		// test provided properties

--- a/test/objects.js
+++ b/test/objects.js
@@ -64,6 +64,7 @@ test('Objects', (t) => {
 	// assert
 
 	t.throws(() => { schema(false, props).assert({ o: {} }); });
+	t.throws(() => { schema(false, props).assert({ o: [] }); });
 
 	// properties
 

--- a/test/objects.js
+++ b/test/objects.js
@@ -54,6 +54,7 @@ test('Objects', (t) => {
 	// creation
 
 	t.throws(() => { object(123); });
+	t.throws(() => { object([]); });
 
 	// optional
 


### PR DESCRIPTION
issue: https://github.com/Wizcorp/my-type/issues/3

Since an empty array shouldn't be considered the same as an object. throw a type error.